### PR TITLE
Expose cancelButtonText and deleteButtonText props on Delete Actions for Translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed `DeleteAction` to expose `cancelButtonText` and `deleteButtonText` props for translations
+
 ## [3.6.0] - 2023-10-26
 
 ### Changed

--- a/src/lib/DataTable/Actions/ActionsCell.tsx
+++ b/src/lib/DataTable/Actions/ActionsCell.tsx
@@ -33,6 +33,8 @@ const ActionsCell = <T, TRouteName>({ actions, collapsed, setCollapsed, keyValue
             title={actions.delete.title}
             text={actions.delete.text}
             iconOnly
+            cancelButtonText={actions.delete.cancelButtonText}
+            deleteButtonText={actions.delete.deleteButtonText}
             onDelete={() => actions?.delete?.action({ key: keyValue, cell: record })}
           />
         )}

--- a/src/lib/DataTable/DataTableInterfaces.ts
+++ b/src/lib/DataTable/DataTableInterfaces.ts
@@ -1,4 +1,4 @@
-/* eslint max-lines: ["error", 270]  */ // Increased max-lines due to the addition of definitions going above the predefined limit.
+/* eslint max-lines: ["error", 271]  */ // Increased max-lines due to the addition of definitions going above the predefined limit.
 import { CSSProperties } from "react";
 import { ActionsPosition, CellFunction, ColumnFilterType, ListSortDirection, QueryFunction, RouteParams } from "./DataTableTypes";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";

--- a/src/lib/DataTable/DataTableInterfaces.ts
+++ b/src/lib/DataTable/DataTableInterfaces.ts
@@ -139,6 +139,8 @@ export interface DataTablePredefinedActionActionParams<T> {
 export interface DeleteAction<T> extends DataTablePredefinedAction<T> {
   title: string;
   text: string;
+  deleteButtonText?: string;
+  cancelButtonText?: string;
 }
 
 export interface DataTablePredefinedActionLink<T, TRouteNames> {


### PR DESCRIPTION
- Expose `cancelButtonText` and `deleteButtonText` props on Delete Actions for Translations